### PR TITLE
Increase the resilience of the data directory location check

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -549,6 +549,17 @@ func (app *App) checkDirData(dirDataName string) string {
 		return path
 	}
 
+	// If the data directory hasn't been found, manually scan the $GOPATH directories
+	rawPaths := os.Getenv("GOPATH")
+	paths := strings.Split(rawPaths, ":")
+	for _, j := range paths {
+		// Checks data path
+		path = filepath.Join(j, "src", "github.com", "g3n", "g3nd", dirDataName)
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+
 	// Shows error message and aborts
 	app.log.Fatal("Data directory NOT FOUND")
 	return ""


### PR DESCRIPTION
This fixes a persistent hassle in g3nd I experience with my development setup, where I use several directories in my `GOPATH`.

Without this PR, to launch this demo I need to manually change the working directory to the g3nd source dir each time.  Forgetting to do so results in an error.

With this PR, if the first level of checks for the data directory doesn't find it then this falls back to scanning the directories given in by the user's `GOPATH` variable.

Turns out it's pretty easy to do, and things now work 100% of the time. :smile: