### PR TITLE
Update to use g3n engine v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,15 @@
 module github.com/g3n/g3nd
 
-go 1.13
+go 1.18
 
 require (
-	github.com/g3n/engine v0.1.1-0.20210609173700-de78e3c4204a
+	github.com/g3n/engine v0.2.0
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
+)
+
+require (
+	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20210410170116-ea3d685f79fb // indirect
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
+	golang.org/x/image v0.0.0-20210607152325-775e3b0c77b9 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/g3n/engine v0.1.1-0.20210609173700-de78e3c4204a h1:kM8J2MSijuPsNuw31DLe+5tvP78+OkRHP6z/XSwplH0=
-github.com/g3n/engine v0.1.1-0.20210609173700-de78e3c4204a/go.mod h1:rnj8jiLdKEDI8VbveKhmdL4rovjjy+uxNP5YROg2x8g=
+github.com/g3n/engine v0.2.0 h1:7dmj4c+3xHcBnYrVmRuVf/oZ2JycxJU9Y+2FQj1Af2Y=
+github.com/g3n/engine v0.2.0/go.mod h1:rnj8jiLdKEDI8VbveKhmdL4rovjjy+uxNP5YROg2x8g=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20210410170116-ea3d685f79fb h1:T6gaWBvRzJjuOrdCtg8fXXjKai2xSDqWTcKFUPuw8Tw=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20210410170116-ea3d685f79fb/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=


### PR DESCRIPTION
I changed the go version to 1.18 from 1.13 as well. Let me know if you would prefer the 1.13